### PR TITLE
fix: 修复高倍镜在加速渲染(AR)下镜内黑屏 - 删除 before-lambda 多余 resetAcceleration

### DIFF
--- a/src/main/java/com/tacz/guns/client/model/BedrockAttachmentModel.java
+++ b/src/main/java/com/tacz/guns/client/model/BedrockAttachmentModel.java
@@ -445,8 +445,6 @@ public class BedrockAttachmentModel extends BedrockAnimatedModel {
             // 重新绑回VAO
             GL30.glBindVertexArray(vao);
 
-            // 画完了, 重新开启加速
-            ARCompat.resetAcceleration();
 
             // 设置镜身需要的模板函数
             RenderSystem.stencilFunc(GL11.GL_EQUAL, 0, 0xFF);
@@ -528,8 +526,6 @@ public class BedrockAttachmentModel extends BedrockAnimatedModel {
             // 重新绑回VAO
             GL30.glBindVertexArray(vao);
 
-            // 画完了, 重新开启加速
-            ARCompat.resetAcceleration();
 
             // 关闭模板缓冲
             RenderSystem.stencilFunc(GL11.GL_ALWAYS, 0, 0xFF);
@@ -600,8 +596,6 @@ public class BedrockAttachmentModel extends BedrockAnimatedModel {
             // 重新绑回VAO
             GL30.glBindVertexArray(vao);
 
-            // 画完了, 重新开启加速
-            ARCompat.resetAcceleration();
 
             // 设置镜身需要的模板函数
             RenderSystem.stencilFunc(GL11.GL_EQUAL, 0, 0xFF);


### PR DESCRIPTION
# [Bugfix] 修复高倍镜 / 组合瞄具在「加速渲染 (Accelerated Rendering)」下镜内黑屏

> 关联 Issue：#55
> 目标仓库：`Sh1roCu/TACZ-Refabricated`，base 分支：`1.20.1`

## 问题

安装 Accelerated Rendering（argon4w）后，第一人称举**高倍镜 / 组合瞄具（scope + sight）**时镜框内整片变黑（stencil 遮罩失效）。

## 根因（基于真实 `BedrockAttachmentModel.java` 源码）

TACZ-Refabricated 内置 `ARCompat` / `ARCompatImpl` 兼容层。`renderScope/renderBoth/renderSight` 命中 `ARCompat.shouldAccelerate()` 时走 `...Accelerated` 版本。

实测日志已确认：黑屏时 `shouldAccelerate=true` 且确实进入 `renderScopeAccelerated` —— **判定本身没问题，bug 在 accelerated 路径内部**。

每个 accelerated 方法的镜身层结构为：
`before(关加速) → 层几何(scopeBodyPath 的 renderTempPart) → after(恢复加速)`。

**Bug**：三个方法的 before-lambda 在 `GL30.glBindVertexArray(vao);` 之后**多调了一次 `ARCompat.resetAcceleration()`**，把加速提前重开。紧随其提交的镜身几何（`scopeBodyPath`）此时加速已是 ON，被 AR 的 `BedrockPartMixin` 拦截进无 stencil 的延迟缓冲 → 模板遮罩失效 → 黑屏。

## 修复

删除以下三处 before-lambda 里、紧接 `GL30.glBindVertexArray(vao);` 之后多余的那一行 `ARCompat.resetAcceleration();`（及「画完了，重新开启加速」注释）。

| 方法 | 所在 lambda |
| --- | --- |
| `renderBothAccelerated` | 镜身层（-943+1）的 before lambda |
| `renderScopeAccelerated` | 镜身层（-943+1）的 before lambda |
| `renderSightAccelerated` | 唯一层的 before lambda |

`after` lambda 里原有的 `resetAcceleration()` **保留**，负责遮罩画完后恢复加速。

```diff
            // 重新绑回VAO
            GL30.glBindVertexArray(vao);
-
-            // 画完了, 重新开启加速
-            ARCompat.resetAcceleration();
-
            // 设置镜身需要的模板函数
            RenderSystem.stencilFunc(GL11.GL_EQUAL, 0, 0xFF);
```

文件：`src/main/java/com/tacz/guns/client/model/BedrockAttachmentModel.java`

## 验证

已对实际运行 jar 做等价字节码修复并**游戏实测通过**：
- 第一人称举高倍镜 / 组合瞄具，镜内**不再黑屏**；
- 切换倍率遮罩正常、无残留/闪烁；
- 非 scope 配件（枪管/握把）与加速行为不受影响（只改了 scope/sight/both 的 accelerated 分支）。

## 影响 / 风险

- 改动极小（删 3 行），不动 `setRenderLayer` 分层架构；
- 加速仅在镜面几何提交那一小段保持关闭，其余帧仍走 AR 加速，性能影响可忽略。
